### PR TITLE
Feat: Tracking anime not in MAL watchlists

### DIFF
--- a/app/routes/content_sync.py
+++ b/app/routes/content_sync.py
@@ -23,7 +23,7 @@ class Status:
     FAIL = "MAL=FAIL"
 
 
-def _handle_content_id(content_id):
+def handle_content_id(content_id):
     """
     Extract the ID of the content and the current episode.
     If ID is a Kitsu ID, get the relevant MAL ID from the database.
@@ -76,7 +76,7 @@ def addon_content_sync(user_id: str, content_type: str, content_id: str, video_h
         return respond_with(
             {'subtitles': [{'id': 1, 'url': 'about:blank', 'lang': Status.SKIP}], 'message': 'Content not supported'})
 
-    mal_id, current_episode = _handle_content_id(content_id)
+    mal_id, current_episode = handle_content_id(content_id)
     if not mal_id:
         return respond_with(
             {'subtitles': [{'id': 1, 'url': 'about:blank', 'lang': Status.INVALID_ID}], 'message': 'Invalid ID'})
@@ -119,5 +119,4 @@ def handle_current_status(status, current_episode, watched_episodes, total_episo
             return "completed", total_episodes
         elif current_episode > watched_episodes:
             return "watching", current_episode
-
     return None, -1

--- a/app/routes/content_sync.py
+++ b/app/routes/content_sync.py
@@ -84,8 +84,12 @@ def addon_content_sync(user_id: str, content_type: str, content_id: str, video_h
     try:
         user = get_valid_user(user_id)
         token = user.get('access_token')
+        track_unlisted_anime = user.get('track_unlisted_anime', False)
         total_episodes, list_status = _get_anime_status(token, mal_id)
-        if not list_status:
+
+        if track_unlisted_anime and not list_status:
+            list_status = {"status": "watching", "num_episodes_watched": 0}
+        elif not list_status:
             return respond_with({'subtitles': [{'id': 1, 'url': 'about:blank', 'lang': Status.NOT_LIST}],
                                  'message': 'Content not in a watchlist'})
 

--- a/run.py
+++ b/run.py
@@ -76,6 +76,9 @@ def configure(userID: str = None):
 
 
 def __handle_addon_options(addon_config_options):
+    """
+    Handle addon configuration parameters that are provided by the user through the configuration page
+    """
     options = {}
     if addon_config_options.get('sort_watchlist') in config.SORT_OPTIONS.values():
         options['sort_watchlist'] = addon_config_options.get('sort_watchlist')
@@ -86,6 +89,11 @@ def __handle_addon_options(addon_config_options):
         options['fetch_streams'] = True
     else:
         options['fetch_streams'] = False
+
+    if addon_config_options.get('track_unlisted_anime', '') == 'true':
+        options['track_unlisted_anime'] = True
+    else:
+        options['track_unlisted_anime'] = False
     return options
 
 

--- a/templates/configure.html
+++ b/templates/configure.html
@@ -58,6 +58,13 @@
                 If you already have the Torrentio addon installed, or don't want streams from torrents, keep this
                 disabled.
             </li>
+            <li>
+                <b>Track unlisted anime:</b> If this option is enabled, MAL-Stremio will add any anime you watch in
+                Stremio to your MAL 'watching' list (if it's not already in your MAL lists).
+                <br>
+                <i>Example: If you start watching Naruto in Stremio for the first time, it will be marked and added to
+                    your MAL 'watching' list.</i>
+            </li>
         </ul>
 
         <div class="note mt-3 mb-3">
@@ -86,6 +93,15 @@
         <select id="fetch_streams" name="fetch_streams" class="form-control-plaintext bg-dark text-white"
                 aria-label="Default select example">
             {% set selected_value = user.get('fetch_streams', False) %}
+            <option value="false" {% if selected_value == False %}selected{% endif %}>Disabled</option>
+            <option value="true" {% if selected_value == True %}selected{% endif %}>Enabled</option>
+        </select>
+
+        <br>
+        <label for="track_unlisted">Track unlisted anime:</label>
+        <select id="track_unlisted_anime" name="track_unlisted_anime" class="form-control-plaintext bg-dark text-white"
+                aria-label="Default select example">
+            {% set selected_value = user.get('track_unlisted_anime', False) %}
             <option value="false" {% if selected_value == False %}selected{% endif %}>Disabled</option>
             <option value="true" {% if selected_value == True %}selected{% endif %}>Enabled</option>
         </select>

--- a/tests/routes/test_content_sync.py
+++ b/tests/routes/test_content_sync.py
@@ -47,7 +47,6 @@ class TestContentSync(unittest.TestCase):
             'num_episodes': 1,
             'my_list_status': {'status': 'watching', 'num_episodes_watched': 0}
         }
-        mock_update_watched_status.status_code = 200
 
         # Test valid movie content ID
         response = self.test_client.get('123/subtitles/anime/kitsu:12345.json')
@@ -58,13 +57,58 @@ class TestContentSync(unittest.TestCase):
 
     @patch('app.routes.mal_client.get_anime_details')
     @patch('app.routes.mal_client.update_watched_status')
+    @patch('app.routes.content_sync.get_valid_user')
+    def test_update_untracked_anime_when_enabled(self, mock_get_user, mock_update_watched_status,
+                                                 mock_get_anime_details):
+        # Mock responses
+        mock_get_user.return_value = {
+            "uid": "123",
+            "id": "123",
+            "access_token": "my access token",
+            "track_unlisted_anime": True
+        }
+        mock_get_anime_details.return_value = {
+            'num_episodes': 1,
+            'my_list_status': None
+        }
+
+        # Test valid movie content ID
+        response = self.test_client.get('123/subtitles/anime/kitsu:12345.json')
+        self.assertEqual(200, response.status_code)
+        self.assertIn('message', response.json)
+        self.assertEqual(Status.OK, response.json['subtitles'][0]['lang'])
+
+    @patch('app.routes.mal_client.get_anime_details')
+    @patch('app.routes.mal_client.update_watched_status')
+    @patch('app.routes.content_sync.get_valid_user')
+    def test_update_untracked_anime_when_disabled(self, mock_get_user, mock_update_watched_status,
+                                                  mock_get_anime_details):
+        # Mock responses
+        mock_get_user.return_value = {
+            "uid": "123",
+            "id": "123",
+            "access_token": "my access token",
+            "track_unlisted_anime": False
+        }
+        mock_get_anime_details.return_value = {
+            'num_episodes': 1,
+            'my_list_status': None
+        }
+
+        # Test valid movie content ID
+        response = self.test_client.get('123/subtitles/anime/kitsu:12345.json')
+        self.assertEqual(200, response.status_code)
+        self.assertIn('message', response.json)
+        self.assertEqual(Status.NOT_LIST, response.json['subtitles'][0]['lang'])
+
+    @patch('app.routes.mal_client.get_anime_details')
+    @patch('app.routes.mal_client.update_watched_status')
     def test_addon_content_sync_valid_movie_set_watched(self, mock_update_watched_status, mock_get_anime_details):
         # Mock responses
         mock_get_anime_details.return_value = {
             'num_episodes': 1,
             'my_list_status': {'status': 'watching', 'num_episodes_watched': 1}
         }
-        mock_update_watched_status.status_code = 200
 
         # Test valid movie content ID
         response = self.test_client.get('123/subtitles/anime/kitsu:12345.json')
@@ -81,7 +125,6 @@ class TestContentSync(unittest.TestCase):
             'num_episodes': 1,
             'my_list_status': {'status': 'watched', 'num_episodes_watched': 1}
         }
-        mock_update_watched_status.status_code = 200
 
         # Test valid movie content ID
         response = self.test_client.get('123/subtitles/anime/kitsu:12345.json')
@@ -98,7 +141,6 @@ class TestContentSync(unittest.TestCase):
             'num_episodes': 3,
             'my_list_status': {'status': 'watching', 'num_episodes_watched': 2}
         }
-        mock_update_watched_status.status_code = 200
 
         # Test valid movie content ID
         response = self.test_client.get('123/subtitles/anime/kitsu:12345:3.json')
@@ -115,7 +157,6 @@ class TestContentSync(unittest.TestCase):
             'num_episodes': 3,
             'my_list_status': {'status': 'watching', 'num_episodes_watched': 2}
         }
-        mock_update_watched_status.status_code = 200
 
         # Test valid movie content ID
         response = self.test_client.get('123/subtitles/anime/kitsu:12345:2.json')

--- a/tests/routes/test_content_sync.py
+++ b/tests/routes/test_content_sync.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 from unittest.mock import patch
 
-from app.routes.content_sync import handle_current_status, _handle_content_id, Status
+from app.routes.content_sync import handle_current_status, handle_content_id, Status
 from run import app
 
 
@@ -15,27 +15,27 @@ class TestContentSync(unittest.TestCase):
         self.test_client = app.test_client()
 
     def test_handle_mal_id(self):
-        content_id, episode = _handle_content_id("mal_12345")
+        content_id, episode = handle_content_id("mal_12345")
         self.assertEqual("12345", content_id)
         self.assertEqual(1, episode)
 
     def test_handle_kitsu_id(self):
-        content_id, episode = _handle_content_id("kitsu:1")
+        content_id, episode = handle_content_id("kitsu:1")
         self.assertEqual(1, content_id)
         self.assertEqual(1, episode)
 
     def test_handle_kitsu_id_with_episode(self):
-        content_id, episode = _handle_content_id("kitsu:1:2")
+        content_id, episode = handle_content_id("kitsu:1:2")
         self.assertEqual(1, content_id)
         self.assertEqual(2, episode)
 
     def test_handle_no_mal_id(self):
-        content_id, episode = _handle_content_id(f"kitsu:{sys.maxsize}")
+        content_id, episode = handle_content_id(f"kitsu:{sys.maxsize}")
         self.assertEqual(None, content_id)
         self.assertEqual(-1, episode)
 
     def test_handle_invalid_id(self):
-        content_id, episode = _handle_content_id("12345")
+        content_id, episode = handle_content_id("12345")
         self.assertEqual(None, content_id)
         self.assertEqual(-1, episode)
 


### PR DESCRIPTION
Allows users to track anime that's not in any of their watchlists whenever they stream it on Stremio.
If this option is enabled, MAL-Stremio will add any anime you watch in Stremio to your MAL 'watching' list (if it's not already in your MAL lists).
*Example: If you start watching Naruto in Stremio for the first time, it will be marked and added to your MAL 'watching' list.*