### PR TITLE
fix: correctly sync ongoing anime (ref. #140)

### DIFF
--- a/app/lib/content_sync.py
+++ b/app/lib/content_sync.py
@@ -23,7 +23,7 @@ def handle_current_status(
     status: str, current_episode: int, watched_episodes: int, total_episodes: int
 ) -> Optional[str]:
     if status in {"watching", "plan_to_watch", "on_hold"}:
-        if current_episode >= total_episodes:
+        if total_episodes > 0 and current_episode >= total_episodes:
             return "completed"
         if current_episode > watched_episodes:
             return "watching"
@@ -71,7 +71,7 @@ def determine_watch_dates(
     set before.The start date is set to the current date if the user is watching the first episode. The finish date
     is set to the current date if the user is watching the last episode.
     :param anime_listing_status: The listing status of the anime in the user's watchlist (if it exists or has been
-    faked for unlisted anime tracking)
+                                    faked for unlisted anime tracking)
     :param current_episode: The current episode being watched
     :param total_episodes: The total number of episodes in the anime
     :return: A tuple of (start_date, finish_date)

--- a/tests/routes/test_content_sync.py
+++ b/tests/routes/test_content_sync.py
@@ -373,6 +373,18 @@ def test_dates_already_set():
         ("on_hold", 3, 2, 3, "completed"),
         ("watching", 2, 1, 3, "watching"),
         ("watching", 3, 2, 3, "completed"),
+        ("plan_to_watch", 0, 0, 0, None),
+        ("watching", 0, 0, 0, None),
+        ("on_hold", 0, 0, 0, None),
+        ("completed", 0, 0, 0, None),
+        ("completed", 1, 1, 0, None),
+        ("on_hold", 1, 1, 0, None),
+        ("watching", 1, 1, 0, None),
+        ("plan_to_watch", 1, 1, 0, None),
+        ("completed", 1, 0, 0, None),
+        ("plan_to_watch", 1, 0, 0, "watching"),
+        ("watching", 1, 0, 0, "watching"),
+        ("on_hold", 1, 0, 0, "watching"),
     ],
 )
 def test_handle_current_status(current_status, current_ep, watched, total, expected):


### PR DESCRIPTION
Fixes ongoing anime being treated as "completed" on every episode watch. Instead ongoing anime are treated as "watching" until `total_episodes > 0` .